### PR TITLE
Automatic dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.3 - 2026-02-22
+### Changed
+- Updated min sdk version to ^3.11.0
+- Updated dependencies
+
 ## 2.1.2 - 2025-12-03
 ### Changed
 - Updated min sdk version to ^3.10.0

--- a/lib/src/models/update_request.dart
+++ b/lib/src/models/update_request.dart
@@ -1,5 +1,5 @@
 // coverage:ignore-file
-// ignore_for_file: constant_identifier_names, invalid_annotation_target
+// ignore_for_file: constant_identifier_names
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,4 +25,5 @@ dev_dependencies:
 dart_pre_commit:
   pull-up-dependencies:
     allowed:
+      - meta
       - test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,26 +1,26 @@
 name: firebase_auth_rest
 description: A platform independent Dart/Flutter Wrapper for the Firebase Authentication API based on REST
-version: 2.1.2
+version: 2.1.3
 homepage: https://github.com/Skycoder42/firebase_auth_rest
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   freezed_annotation: ^3.1.0
   http: ^1.6.0
-  json_annotation: ^4.9.0
+  json_annotation: ^4.11.0
 
 dev_dependencies:
-  build_runner: ^2.10.4
+  build_runner: ^2.11.1
   coverage: ^1.15.0
-  dart_pre_commit: ^6.1.0
-  dart_test_tools: ^7.0.1
-  freezed: ^3.2.3
-  json_serializable: ^6.11.2
+  dart_pre_commit: ^6.1.1+1
+  dart_test_tools: ^7.0.2
+  freezed: ^3.2.5
+  json_serializable: ^6.13.0
   meta: ^1.17.0
   mocktail: ^1.0.4
-  test: ^1.26.3
+  test: ^1.29.0
 
 dart_pre_commit:
   pull-up-dependencies:


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for firebase_auth_rest to ^3.11.0
### Dependency Updates
```

Changed 7 constraints in pubspec.yaml:
  json_annotation: ^4.9.0 -> ^4.11.0
  build_runner: ^2.10.4 -> ^2.11.1
  dart_pre_commit: ^6.1.0 -> ^6.1.1+1
  dart_test_tools: ^7.0.1 -> ^7.0.2
  freezed: ^3.2.3 -> ^3.2.5
  json_serializable: ^6.11.2 -> ^6.13.0
  test: ^1.26.3 -> ^1.29.0
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 93.0.0 (96.0.0 available)
  analysis_server_plugin 0.3.7 (0.3.10 available)
  analyzer 10.0.1 (10.2.0 available)
  analyzer_plugin 0.14.1 (0.14.4 available)
  meta 1.17.0 (1.18.1 available)
No dependencies changed.
5 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
